### PR TITLE
Update networking-cisco macro's to support newton-eol

### DIFF
--- a/jenkins/jobs/networking-cisco-macros.yaml
+++ b/jenkins/jobs/networking-cisco-macros.yaml
@@ -42,6 +42,8 @@
           #!/bin/bash -xe
           if [[ "{zuul-branch}" == "mitaka" ]]; then
             export OVERRIDE_ZUUL_BRANCH=mitaka-eol
+          elif [[ "{zuul-branch}" == "newton" ]]; then
+            export OVERRIDE_ZUUL_BRANCH=newton-eol
           elif [[ "{zuul-branch}" == "current" ]]; then
             export OVERRIDE_ZUUL_BRANCH=
           else
@@ -60,6 +62,8 @@
                 #!/bin/bash -xe
                 if [[ "{zuul-branch}" == "mitaka" ]]; then
                   export OVERRIDE_ZUUL_BRANCH=mitaka-eol
+                elif [[ "{zuul-branch}" == "newton" ]]; then
+                  export OVERRIDE_ZUUL_BRANCH=newton-eol
                 elif [[ "{zuul-branch}" == "current" ]]; then
                   export OVERRIDE_ZUUL_BRANCH=
                 else


### PR DESCRIPTION
This patch makes the change to jenkins macros to switch stable/newton to
newton-eol. Playbook changes which could effect the other tests will
follow in separate commits. 