### PR TITLE
Remove devstack-gate cherry-picks now that the fix has merged

### DIFF
--- a/jenkins/jobs/networking-cisco-macros.yaml
+++ b/jenkins/jobs/networking-cisco-macros.yaml
@@ -40,11 +40,11 @@
     builders:
       - shell: |
           #!/bin/bash -xe
-          if [[ "{zuul-branch}" == "mitaka" ]]; then
-            export OVERRIDE_ZUUL_BRANCH=mitaka-eol
-          elif [[ "{zuul-branch}" == "newton" ]]; then
-            export OVERRIDE_ZUUL_BRANCH=newton-eol
-          elif [[ "{zuul-branch}" == "current" ]]; then
+          #if [[ "{zuul-branch}" == "mitaka" ]]; then
+          #  export OVERRIDE_ZUUL_BRANCH=mitaka-eol
+          #elif [[ "{zuul-branch}" == "newton" ]]; then
+          #  export OVERRIDE_ZUUL_BRANCH=newton-eol
+          if [[ "{zuul-branch}" == "current" ]]; then
             export OVERRIDE_ZUUL_BRANCH=
           else
             export OVERRIDE_ZUUL_BRANCH=stable/{zuul-branch}
@@ -60,11 +60,11 @@
           builders:
             - shell: |
                 #!/bin/bash -xe
-                if [[ "{zuul-branch}" == "mitaka" ]]; then
-                  export OVERRIDE_ZUUL_BRANCH=mitaka-eol
-                elif [[ "{zuul-branch}" == "newton" ]]; then
-                  export OVERRIDE_ZUUL_BRANCH=newton-eol
-                elif [[ "{zuul-branch}" == "current" ]]; then
+                #if [[ "{zuul-branch}" == "mitaka" ]]; then
+                #  export OVERRIDE_ZUUL_BRANCH=mitaka-eol
+                #elif [[ "{zuul-branch}" == "newton" ]]; then
+                #  export OVERRIDE_ZUUL_BRANCH=newton-eol
+                if [[ "{zuul-branch}" == "current" ]]; then
                   export OVERRIDE_ZUUL_BRANCH=
                 else
                   export OVERRIDE_ZUUL_BRANCH=stable/{zuul-branch}

--- a/playbooks/roles/run-devstack-gate/files/custom_devstack_gate_hook
+++ b/playbooks/roles/run-devstack-gate/files/custom_devstack_gate_hook
@@ -3,8 +3,8 @@ function pre_test_hook {
   $ANSIBLE all -i $WORKSPACE/inventory -m "replace" -a "path=/opt/stack/new/requirements/upper-constraints.txt regexp='libvirt-python.*' replace='libvirt-python===3.2.0'"
 
   # Cherrypick changes to devstack-gate to allow for testing against EOL tags.
-  (cd /opt/stack/new/devstack-gate && \
-   git fetch https://git.openstack.org/openstack-infra/devstack-gate refs/changes/46/510946/1 && git cherry-pick FETCH_HEAD && \
-   git fetch https://git.openstack.org/openstack-infra/devstack-gate refs/changes/45/512245/2 && git cherry-pick FETCH_HEAD)
+  #(cd /opt/stack/new/devstack-gate && \
+  # git fetch https://git.openstack.org/openstack-infra/devstack-gate refs/changes/46/510946/1 && git cherry-pick FETCH_HEAD && \
+  # git fetch https://git.openstack.org/openstack-infra/devstack-gate refs/changes/45/512245/2 && git cherry-pick FETCH_HEAD)
 }
 export -f pre_test_hook


### PR DESCRIPTION
This patch removes the devstack gate cherry-picks for EOL tags now that
the fix has merged into devstack-gate.