### PR TITLE
Template openstack project cherrypicks from ansible

### DIFF
--- a/playbooks/roles/run-devstack-gate/defaults/main.yaml
+++ b/playbooks/roles/run-devstack-gate/defaults/main.yaml
@@ -34,3 +34,12 @@ devstack_gate_env:
   OVERRIDE_NOVA_PROJECT_BRANCH: |-
     {% if override_zuul_branch == 'newton-eol' -%}stable/newton
     {%- else -%}{{override_zuul_branch}}{%- endif -%}
+
+openstack_project_cherrypicks: {}
+
+# yamllint disable rule:line-length
+default_openstack_project_cherrypicks:
+  all:
+    devstack-gate:
+      - "https://git.openstack.org/openstack-infra/devstack-gate refs/changes/25/523925/1"
+# yamllint enable

--- a/playbooks/roles/run-devstack-gate/files/custom_devstack_gate_hook
+++ b/playbooks/roles/run-devstack-gate/files/custom_devstack_gate_hook
@@ -1,9 +1,0 @@
-function pre_test_hook {
-  # Hack the version of libvirt-python so its compatible with centos7
-  $ANSIBLE all -i $WORKSPACE/inventory -m "replace" -a "path=/opt/stack/new/requirements/upper-constraints.txt regexp='libvirt-python.*' replace='libvirt-python===3.2.0'"
-
-  # Cherrypick changes to devstack-gate to allow for testing against EOL tags.
-  (cd /opt/stack/new/devstack-gate && \
-   git fetch https://git.openstack.org/openstack-infra/devstack-gate refs/changes/25/523925/1 && git cherry-pick FETCH_HEAD)
-}
-export -f pre_test_hook

--- a/playbooks/roles/run-devstack-gate/tasks/main.yaml
+++ b/playbooks/roles/run-devstack-gate/tasks/main.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Copy custom gate hooks into workspace
-  copy:
+  template:
     src: custom_devstack_gate_hook
     dest: "{{ workspace }}/custom_devstack_gate_hook"
 

--- a/playbooks/roles/run-devstack-gate/templates/custom_devstack_gate_hook
+++ b/playbooks/roles/run-devstack-gate/templates/custom_devstack_gate_hook
@@ -1,0 +1,34 @@
+{# Macro for rendering out cherry pick commands #}
+{%- macro render_cherrypicks(cherrypicks) %}
+  {%- for version, projects in cherrypicks.items() %}
+    {%- if version == "all" or version == override_zuul_branch %}
+      {%- for project, patches in projects.items() %}
+        {{- "# Cherrypick pre-merge changes to %s\n" % project }}
+        {{- "(cd /opt/stack/new/%s" % project }}
+        {%- for patch in patches %}
+          {%- if "http" in patch %}
+            {{- " && \\\n git fetch %s && git cherry-pick FETCH_HEAD" % patch }}
+          {%- else %}
+            {{- " && \\\n git apply %s" % patch }}
+          {%- endif %}
+        {%- endfor %})
+        {{- "\n" }}
+      {%- endfor %}
+    {%- endif %}
+  {%- endfor %}
+{%- endmacro -%}
+
+function pre_test_hook {
+  # Hack the version of libvirt-python so its compatible with centos7
+  $ANSIBLE all -i $WORKSPACE/inventory -m "replace" -a "path=/opt/stack/new/requirements/upper-constraints.txt regexp='libvirt-python.*' replace='libvirt-python===3.2.0'"
+
+  #########################################
+  # Default cherrypicks applied to all jobs
+  #########################################
+  {{ render_cherrypicks(default_openstack_project_cherrypicks) | indent(2) }}
+  #############################################
+  # Custom cherrypicks applied to only this job
+  #############################################
+  {{ render_cherrypicks(openstack_project_cherrypicks) | indent(2) }}
+}
+export -f pre_test_hook


### PR DESCRIPTION
This change makes it much easier to cherry-pick a pre-merge change into
a CI job at the right point in the devstack-gate process, allowing for
easier maintenance/tracking of the patches that get injected into jobs.