### PR TITLE
Ensure nexus and ucsm jobs use the correct variable for vlans

### DIFF
--- a/playbooks/templates/nexus_job_local_conf.j2
+++ b/playbooks/templates/nexus_job_local_conf.j2
@@ -1,8 +1,8 @@
 enable_plugin networking-cisco https://git.openstack.org/openstack/networking-cisco
 enable_service net-cisco
 
-ML2_VLAN_RANGES=nexusnet:{{claimed_vlan_range}}
-OVS_VLAN_RANGES=nexusnet:{{claimed_vlan_range}}
+ML2_VLAN_RANGES=nexusnet:{{ansible_local.claimed_vlans.min_vlan}}:{{ansible_local.claimed_vlans.max_vlan}}
+OVS_VLAN_RANGES=nexusnet:{{ansible_local.claimed_vlans.min_vlan}}:{{ansible_local.claimed_vlans.max_vlan}}
 
 ENABLE_TENANT_VLANS=True
 OVS_BRIDGE_MAPPINGS=public:br-ex,nexusnet:br-nexusnet

--- a/playbooks/templates/ucsm_job_local_conf.j2
+++ b/playbooks/templates/ucsm_job_local_conf.j2
@@ -1,7 +1,7 @@
 enable_plugin networking-cisco https://git.openstack.org/openstack/networking-cisco
 enable_service net-cisco
-ML2_VLAN_RANGES=ucsmnet:{{claimed_vlan_range}}
-OVS_VLAN_RANGES=ucsmnet:{{claimed_vlan_range}}
+ML2_VLAN_RANGES=nexusnet:{{ansible_local.claimed_vlans.min_vlan}}:{{ansible_local.claimed_vlans.max_vlan}}
+OVS_VLAN_RANGES=nexusnet:{{ansible_local.claimed_vlans.min_vlan}}:{{ansible_local.claimed_vlans.max_vlan}}
 ENABLE_TENANT_VLANS=True
 OVS_BRIDGE_MAPPINGS=public:br-ex,ucsmnet:br-ucsmnet
 Q_ML2_PLUGIN_MECHANISM_DRIVERS=openvswitch,linuxbridge,cisco_ucsm


### PR DESCRIPTION
The change to the vlan claim role missed two locations where those items
are used. This patch fixes that.