### PR TITLE
ASR1K parallel job experimental queue/node/jobs

### DIFF
--- a/jenkins/jobs/projects.yaml
+++ b/jenkins/jobs/projects.yaml
@@ -56,3 +56,6 @@
         - 'gate-{name}-dsvm-tempest-smoke-{job-name}-{zuul-branch}-{node}':
             job-name: asr1k
             node: centos-7-asr
+        - 'gate-{name}-dsvm-tempest-smoke-{job-name}-{zuul-branch}-{node}':
+            job-name: asr1k-prll
+            node: centos-7-asr-prll

--- a/nodepool/nodepool.yaml
+++ b/nodepool/nodepool.yaml
@@ -62,6 +62,13 @@ labels:
     min-ready: 1
     providers:
       - name: devstack-rocket-man-asr
+  - name: centos-7-asr-prll
+    image: centos-7-asr-prll
+    ready-script: configure_mirror.sh
+    min-ready: 1
+    providers:
+      - name: devstack-rocket-man-asr-prll
+
 
 providers:
   - name: devstack-rocket-man
@@ -182,6 +189,28 @@ providers:
         private-key: /home/nodepool/.ssh/id_rsa
         name-filter: 'Performance'
         config-drive: true
+  - name: devstack-rocket-man-asr-prll
+    username: admin
+    password: secret
+    project-name: demo
+    auth-url: http://192.133.156.19/identity
+    api-timeout: 60
+    boot-timeout: 120
+    max-servers: 3
+    rate: 1
+    # Remove this when glean has support for ipv6 on centos
+    ipv6-preferred: false
+    image-type: qcow2
+    template-hostname: '{image.name}-{timestamp}'
+    images:
+      - name: centos-7-asr-prll
+        min-ram: 8192
+        diskimage: centos-7
+        username: jenkins
+        private-key: /home/nodepool/.ssh/id_rsa
+        name-filter: 'Performance'
+        config-drive: true
+
 
 targets:
   - name: jenkins1

--- a/zuul/layout.yaml
+++ b/zuul/layout.yaml
@@ -71,7 +71,6 @@ pipelines:
     failure:
       gerrit: {}
 
-
 jobs:
   - name: ^.*$
     parameter-function: set_node_options
@@ -132,6 +131,10 @@ projects:
       - gate-ironic-dsvm-tempest-smoke-ironic-cimc-nexus-ocata-centos-7-cimc:
         - gate-ironic-dsvm-tempest-smoke-ironic-cimc-nexus-pike-centos-7-cimc
         - gate-ironic-dsvm-tempest-smoke-ironic-cimc-nexus-newton-centos-7-cimc
+      - gate-networking-cisco-dsvm-tempest-smoke-asr1k-prll-ocata-centos-7-asr-prll
+      - gate-networking-cisco-dsvm-tempest-smoke-asr1k-prll-pike-centos-7-asr-prll
+      - gate-networking-cisco-dsvm-tempest-smoke-asr1k-prll-newton-centos-7-asr-prll
+
 
   - name: openstack/ironic
     check:


### PR DESCRIPTION
    The intent of this patch is to add jobs for experimenting
    with parallelizing ASR1K jobs. The new jobs should not be triggered
    along with the existing (non-parallel) ASR jobs.  The following
    should be used in networking-cisco commit messages to test the
    ASR parallel execution jobs:
       Cisco-CI-Experimental-Regex: .*-asr1k-prll.*

The follow-on work will do the experimentation in a job implementation branch via creating asr1k-prll*.yaml playbooks.  

Once everything is working for the parallelization of the ASR1K jobs, we'll have to remove the centos-7-asr-prll nodeprovider node and the devstack-rocket-man-asr-prll provider.  We'd just modify the devstack-rocket-man-asr provider to increase max-servers and add the changes to the existing ASR1K job playbooks.  Additionally, the job implementation will merge as a modification to the existing ASR1K jobs so all the -prll jobs will be removed.