### PR TITLE
Pin version of jenkins job builder to 1.6.2 as 2.0.0+ is broken for us

### DIFF
--- a/tools/run-compare-xml.sh
+++ b/tools/run-compare-xml.sh
@@ -23,6 +23,7 @@ mkdir .test
 cd .test
 /usr/zuul-env/bin/zuul-cloner -m ../tools/run-compare-clonemap.yaml --cache-dir /opt/git git://git.openstack.org openstack-infra/jenkins-job-builder
 cd jenkins-job-builder
+git checkout 1.6.2
 # These are $WORKSPACE/.test/jenkins-job-builder/.test/...
 mkdir -p .test/old/config
 mkdir -p .test/old/out

--- a/tools/run-layout.sh
+++ b/tools/run-layout.sh
@@ -19,7 +19,7 @@ config=$(readlink -f tools/jenkins.ini)
 mkdir -p .test
 cd .test
 [ -d zuul ] || git clone https://git.openstack.org/openstack-infra/zuul --depth 1 -b 2.6.0
-[ -d jenkins-job-builder ] || git clone https://git.openstack.org/openstack-infra/jenkins-job-builder --depth 1
+[ -d jenkins-job-builder ] || git clone https://git.openstack.org/openstack-infra/jenkins-job-builder --depth 1 -b 1.6.2
 cd jenkins-job-builder
 # These are $WORKSPACE/.test/jenkins-job-builder/.test/...
 mkdir -p .test/new/config


### PR DESCRIPTION
Change-Id: I1e1aea2034cec53bdccb704a4fa7f78edcf005cf