### PR TITLE
Fix pin on jenkins-job-builder dependency in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ ignore = E125,E129,E402,H,W503
 
 [testenv:jjb]
 basepython = python2.7
-deps = jenkins-job-builder
+deps = jenkins-job-builder==1.6.2
 whitelist_externals =
   mkdir
   rm


### PR DESCRIPTION
Change-Id: I8c4aace56039789d5d353c9c7b2b1193715e1fbe