### PR TITLE
Fix dsvm match typo

### DIFF
--- a/zuul/layout.yaml
+++ b/zuul/layout.yaml
@@ -82,7 +82,7 @@ jobs:
     tags:
       - "reusenode"
 
-  - name: ^.*-dvsm-.*$
+  - name: ^.*-dsvm-.*$
     skip-if:
       - all-files-match-any:
         - ^.*\.rst$


### PR DESCRIPTION
zuul skip matches don't work due to typo