### PR TITLE
Cherry-pick / Patch in an upper constraint for setuptools version 39

### DIFF
--- a/playbooks/roles/run-devstack-gate/defaults/main.yaml
+++ b/playbooks/roles/run-devstack-gate/defaults/main.yaml
@@ -34,6 +34,12 @@ default_openstack_project_cherrypicks:
   all:
     devstack-gate:
       - "https://git.openstack.org/openstack-infra/devstack-gate refs/changes/26/530726/4"
+  mitaka:
+    requirements:
+      - "{{workspace}}/patches/0001-Add-upper-constraint-for-setuptool-39-on-stable-newt.patch"
+  newton:
+    requirements:
+      - "https://git.openstack.org/openstack/requirements refs/changes/69/555269/1"
 # yamllint enable
 
 run_devstack_gate_unstack: false

--- a/playbooks/roles/run-devstack-gate/files/0001-Add-upper-constraint-for-setuptool-39-on-stable-newt.patch
+++ b/playbooks/roles/run-devstack-gate/files/0001-Add-upper-constraint-for-setuptool-39-on-stable-newt.patch
@@ -1,0 +1,32 @@
+From 9aa7b4054c04db397d3b6a30b7be924d2d7f5011 Mon Sep 17 00:00:00 2001
+From: Sam Betts <sam@code-smash.net>
+Date: Thu, 22 Mar 2018 11:45:35 +0000
+Subject: [PATCH] Add upper constraint for setuptool >=39 on stable/newton
+
+OpenStack stable/newton and older is now incompatible with the latest
+version of setuptools so we need to add an upper constraint to prevent
+us installing a version that is too new. Setuptools version 39.0.0
+removes the ability to index the result of parse_version which is used
+by oslo_utils.versionutils and therefore breaks anyone using those
+utility functions.
+
+Change-Id: I93e940538a943fba2d426a714a187e7f6390ceab
+---
+ upper-constraints.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/upper-constraints.txt b/upper-constraints.txt
+index 0cdcd134..7e94762a 100644
+--- a/upper-constraints.txt
++++ b/upper-constraints.txt
+@@ -331,6 +331,7 @@ selenium===2.52.0
+ semantic-version===2.5.0
+ seqdiag===0.9.5
+ service-identity===16.0.0
++setuptools==38.7.0
+ simplegeneric===0.8.1
+ simplejson===3.8.2
+ singledispatch===3.4.0.3
+-- 
+2.11.0
+

--- a/playbooks/roles/run-devstack-gate/tasks/main.yaml
+++ b/playbooks/roles/run-devstack-gate/tasks/main.yaml
@@ -31,6 +31,7 @@
     dest: "{{ workspace }}/patches/"
   with_items:
     - devstack_mitaka_providernet_pub_vlan.patch
+    - 0001-Add-upper-constraint-for-setuptool-39-on-stable-newt.patch
   when: "'mitaka' in override_zuul_branch"
 
 - name: Copy devstack gate to devstack gate safe

--- a/playbooks/roles/run-devstack-gate/templates/custom_devstack_gate_hook
+++ b/playbooks/roles/run-devstack-gate/templates/custom_devstack_gate_hook
@@ -25,7 +25,7 @@ function pre_test_hook {
 {% if ansible_distribution == "CentOS" %}
   # Hack the version of libvirt-python so its compatible with centos7
   $ANSIBLE all -i $WORKSPACE/inventory -m "replace" -a "path=/opt/stack/new/requirements/upper-constraints.txt regexp='libvirt-python.*' replace='libvirt-python===3.2.0'"
-
+  ( cd /opt/stack/new/requirements && git commit -m "pin libvirt-python version 3.2.0" )
 {% endif %}
   #########################################
   # Default cherrypicks applied to all jobs

--- a/playbooks/roles/run-devstack-gate/templates/custom_devstack_gate_hook
+++ b/playbooks/roles/run-devstack-gate/templates/custom_devstack_gate_hook
@@ -25,7 +25,7 @@ function pre_test_hook {
 {% if ansible_distribution == "CentOS" %}
   # Hack the version of libvirt-python so its compatible with centos7
   $ANSIBLE all -i $WORKSPACE/inventory -m "replace" -a "path=/opt/stack/new/requirements/upper-constraints.txt regexp='libvirt-python.*' replace='libvirt-python===3.2.0'"
-  ( cd /opt/stack/new/requirements && git commit -m "pin libvirt-python version 3.2.0" )
+  $ANSIBLE all -i $WORKSPACE/inventory -m "shell" -a 'cd /opt/stack/new/requirements && git commit -a -m "pin libvirt-python version 3.2.0"'
 {% endif %}
   #########################################
   # Default cherrypicks applied to all jobs

--- a/playbooks/roles/run-devstack-gate/templates/custom_devstack_gate_hook
+++ b/playbooks/roles/run-devstack-gate/templates/custom_devstack_gate_hook
@@ -27,6 +27,8 @@ function pre_test_hook {
   $ANSIBLE all -i $WORKSPACE/inventory -m "replace" -a "path=/opt/stack/new/requirements/upper-constraints.txt regexp='libvirt-python.*' replace='libvirt-python===3.2.0'"
   $ANSIBLE all -i $WORKSPACE/inventory -m "shell" -a 'cd /opt/stack/new/requirements && git commit -a -m "pin libvirt-python version 3.2.0"'
 {% endif %}
+
+  $ANSIBLE all -i $WORKSPACE/inventory -m "shell" -a '
   #########################################
   # Default cherrypicks applied to all jobs
   #########################################
@@ -34,7 +36,8 @@ function pre_test_hook {
   #############################################
   # Custom cherrypicks applied to only this job
   #############################################
-  {{ render_cherrypicks(openstack_project_cherrypicks) | indent(2) }}
+  {{ render_cherrypicks(openstack_project_cherrypicks) | indent(2) }}'
+
 {% if custom_pre_test_hook_script %}
 
   {{ custom_pre_test_hook_script | indent(2) }}


### PR DESCRIPTION
Newton or older OpenStack is not compatible with setuptools versions >39
due to using a feature that is no longer supported going forward. So
this patch cherry-picks in an upper constraint pinning the max version
of setuptools to <39.

Change-Id: Iadd775eeaccbb6f456639bbeb52c5ad0aa30ef0e