### PR TITLE
ASR: add per-job variation to public IP cidr (FIP range)

### DIFF
--- a/playbooks/dsvm-tempest-smoke-asr1k-job-pre.yaml
+++ b/playbooks/dsvm-tempest-smoke-asr1k-job-pre.yaml
@@ -10,10 +10,12 @@
       {{ ci_node_interfaces }} +
       {{ routers|map('extract', connections, ['data', 'port'])|list }}
   roles:
+    - claim-a-region-id
     - claim-a-vlan-range
     - configure-vlan-for-hosts
     - role: setup-vlan-subinterface
-      ip_cidr: 10.254.0.1/24
+      region_id: "{{ansible_local.asr_region_id.region_id}}"
+      regid_num: "{{region_id|regex_replace('L3FR0*', '')}}"
+      ip_cidr: "10.254.{{regid_num}}.1/24"
       subintf_vlan: "{{ ansible_local.claimed_vlans.min_vlan }}"
       subintf_mtu: "{{ physnet_mtu }}"
-    - claim-a-region-id

--- a/playbooks/dsvm-tempest-smoke-asr1k-job.yaml
+++ b/playbooks/dsvm-tempest-smoke-asr1k-job.yaml
@@ -9,9 +9,10 @@
     ml2_vlan_min: "{{ansible_local.claimed_vlans.min_vlan + 1}}"
     devstack_local_conf:
       "{{ lookup('template', 'templates/asr1k_job_local_conf.j2') }}"
+    pubip_cidr_var: "{{ansible_local.asr_region_id.region_id|regex_replace('L3FR0*', '')}}"
     devstack_gate_env_override:
-      DEVSTACK_GATE_FLOATING_RANGE: 10.254.0.0/24
-      DEVSTACK_GATE_PUBLIC_NETWORK_GATEWAY: "10.254.0.1"
+      DEVSTACK_GATE_FLOATING_RANGE: "10.254.{{pubip_cidr_var}}.0/24"
+      DEVSTACK_GATE_PUBLIC_NETWORK_GATEWAY: "10.254.{{pubip_cidr_var}}.1"
   roles:
     - role: run-devstack-gate
       openstack_project_cherrypicks:


### PR DESCRIPTION
- use the numeric portion of the regionID value as the 3rd octet
  in floating IP address cidr.

Concurrent jobs need unique public IP cidrs to work or they screw router config up and all fail.

Runs in Experimental queue of https://review.openstack.org/#/c/542324 