### PR TITLE
Cisco-CI-Experimental-Branch:adding_experimental_ciscozm

### DIFF
--- a/playbooks/templates/zm_cinder_local_conf.j2
+++ b/playbooks/templates/zm_cinder_local_conf.j2
@@ -10,7 +10,7 @@ enable_service q-dhcp
 enable_service q-l3
 
 disable_service q-fwaas
-enable_service q-meta
+#enable_service q-meta
 enable_service neutron
 enable_service c-api
 enable_service c-sch

--- a/playbooks/templates/zm_cinder_local_conf.j2
+++ b/playbooks/templates/zm_cinder_local_conf.j2
@@ -10,7 +10,6 @@ enable_service q-dhcp
 enable_service q-l3
 
 disable_service q-fwaas
-#enable_service q-meta
 enable_service neutron
 enable_service c-api
 enable_service c-sch
@@ -29,6 +28,12 @@ PUBLIC_BRIDGE=br-int
 DATABASE_TYPE=mysql
 
 CINDER_ENABLED_BACKENDS=dell:EMC-HighPerformance
+
+[[post-config|$NOVA_CONF]]
+[DEFAULT]
+vif_plugging_is_fatal = false
+vif_plugging_timeout = 0
+
 [[post-config|$CINDER_CONF]]
 [DEFAULT]
 zoning_mode = fabric

--- a/zuul/layout.yaml
+++ b/zuul/layout.yaml
@@ -162,7 +162,7 @@ projects:
       - ironic-dsvm-tempest-ironic-cimc-current-centos-7-cimc
 
   - name: openstack/cinder
-    check:
-      - cinder-dsvm-tempest-cisco-zonemanager-current-ubuntu-czm
+    #check:
+    #  - cinder-dsvm-tempest-cisco-zonemanager-current-ubuntu-czm
     experimental:
       - cinder-dsvm-tempest-cisco-zonemanager-current-ubuntu-czm


### PR DESCRIPTION
To Reduce the runtime, Removing the metadata information, as it fails to get cleaned up on unstack.