### PR TITLE
Cap pip version less than 10 for mitaka/newton

### DIFF
--- a/playbooks/roles/run-devstack-gate/defaults/main.yaml
+++ b/playbooks/roles/run-devstack-gate/defaults/main.yaml
@@ -35,9 +35,15 @@ default_openstack_project_cherrypicks:
     devstack-gate:
       - "https://git.openstack.org/openstack-infra/devstack-gate refs/changes/26/530726/4"
   mitaka:
+    devstack:
+      - "https://git.openstack.org/openstack-dev/devstack refs/changes/94/561594/1"
+      - "https://git.openstack.org/openstack-dev/devstack refs/changes/16/561416/3"
     requirements:
       - "{{workspace}}/patches/0001-Add-upper-constraint-for-setuptool-39-on-stable-newt.patch"
   newton:
+    devstack:
+      - "https://git.openstack.org/openstack-dev/devstack refs/changes/94/561594/1"
+      - "https://git.openstack.org/openstack-dev/devstack refs/changes/16/561416/3"
     requirements:
       - "https://git.openstack.org/openstack/requirements refs/changes/69/555269/1"
 # yamllint enable

--- a/tools/jenkins.ini
+++ b/tools/jenkins.ini
@@ -1,2 +1,5 @@
 [jenkins]
-url=https://localhost:123456
+user=jenkins
+password=1234567890abcdef1234567890abcdef
+url=https://jenkins.example.com
+query_plugins_info=False


### PR DESCRIPTION
Pip 10 has broken many many things, upstream has already capped pip to
<10 for ocata onwards. This patch backports the cap for releases not
supported upstream.

Change-Id: I9bdc9ffbcd9f2d279bb91339cb97f4ed9f434422