### PR TITLE
Re-enabled check for cinder-dsvm-tempest-cisco-zonemanager-current-ub…

### DIFF
--- a/zuul/layout.yaml
+++ b/zuul/layout.yaml
@@ -164,7 +164,7 @@ projects:
       - ironic-dsvm-tempest-ironic-ucsm-current-centos-7-ucsm
 
   - name: openstack/cinder
-    #check:
-    #  - cinder-dsvm-tempest-cisco-zonemanager-current-ubuntu-czm
+    check:
+      - cinder-dsvm-tempest-cisco-zonemanager-current-ubuntu-czm
     experimental:
       - cinder-dsvm-tempest-cisco-zonemanager-current-ubuntu-czm


### PR DESCRIPTION
…untu-czm job

check was disabled due to neutron issues.
re-enabled check as the neutron issue got resolved.

https://review.openstack.org/570511